### PR TITLE
Update webpack.config.js

### DIFF
--- a/templates/react-skeleton/webpack.config.js
+++ b/templates/react-skeleton/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = {
         exclude: /node_modules/,
         loader: "babel",
         query: {
-          presets: ["react", "es2015", "stage-1"]
+          presets: ["react", "env"]
         }
       }
     ]


### PR DESCRIPTION
There has been updates to babel. Making es2015, and stage-1 incorrect. Updated to env, and the deprecation of stages.
References.
Staging
https://babeljs.io/blog/2018/07/27/removing-babels-stage-presets
https://babeljs.io/docs/en/babel-preset-stage-1
ES2015
https://babeljs.io/docs/en/env/