### PR TITLE
remove 'es2015' and 'stage-1' from babel presets

### DIFF
--- a/templates/react-skeleton/webpack.config.js
+++ b/templates/react-skeleton/webpack.config.js
@@ -1,31 +1,31 @@
 module.exports = {
-  entry: ["./src/index.js"],
-  output: {
-    path: __dirname,
-    publicPath: "/",
-    filename: "bundle.js"
-  },
-  mode: "development",
-  module: {
-    rules: [
-      {
-        exclude: /node_modules/,
-        loader: "babel",
-        query: {
-          presets: ["react", "es2015", "stage-1"]
-        }
-      }
-    ]
-  },
-  resolve: {
-    extensions: [".js", ".jsx"],
-    modules: ["node_modules"]
-  },
-  resolveLoader: {
-    moduleExtensions: ["-loader"]
-  },
-  devServer: {
-    historyApiFallback: true,
-    contentBase: "./"
-  }
+	entry: ["./src/index.js"],
+	output: {
+		path: __dirname,
+		publicPath: "/",
+		filename: "bundle.js"
+	},
+	mode: "development",
+	module: {
+		rules: [
+			{
+				exclude: /node_modules/,
+				loader: "babel",
+				query: {
+					presets: ["react"]
+				}
+			}
+		]
+	},
+	resolve: {
+		extensions: [".js", ".jsx"],
+		modules: ["node_modules"]
+	},
+	resolveLoader: {
+		moduleExtensions: ["-loader"]
+	},
+	devServer: {
+		historyApiFallback: true,
+		contentBase: "./"
+	}
 };


### PR DESCRIPTION
Students were running into an issue with spinning up the development server immediately following the install. For my class, I would remove the two mentioned presets in the webpack.config.js and it worked fine. I'm submitting this pull request for review, but if the fix isn't valid please let me know. Thanks you.